### PR TITLE
Bump version number. add licence

### DIFF
--- a/outputs/jira/pyproject.toml
+++ b/outputs/jira/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "opsbox-jira-output"
-version = "0.1.4"
+version = "0.1.5"
 description = "Jira backlog output for opsbox"
 readme = "README.md"
-license = {file = "LICENSE"}
+license = {file = "LICENCE.txt"}
 requires-python = "==3.11.*"
 dependencies = [
     "llama-index>=0.12.6",


### PR DESCRIPTION
Bump the jira version number, make sure the licence is included in the pyproject correctly.