### PR TITLE
Fix/rego handler opa mac dl

### DIFF
--- a/handlers/rego_handler/pyproject.toml
+++ b/handlers/rego_handler/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opsbox-rego-handler"
-version = "0.2.2"
+version = "0.2.3"
 description = "Handles rego plugins for opsbox"
 readme = "README.md"
 license = {file = "LICENCE.txt"}

--- a/handlers/rego_handler/rego_handler/rego_handler.py
+++ b/handlers/rego_handler/rego_handler/rego_handler.py
@@ -430,7 +430,7 @@ class ExecLocal(RegoExecution):
             case ("darwin", "arm64"):
                 url = f"{base_url}/opa_darwin_arm64_static"
             case ("darwin", "amd64") | ("darwin", "x86_64"):
-                url = f"{base_url}/opa_darwin_amd64_static"
+                url = f"{base_url}/opa_darwin_amd64"
             case ("windows", "amd64") | ("windows", "x86_64"):
                 url = f"{base_url}/opa_windows_amd64.exe"
             case _:


### PR DESCRIPTION
* Updated the project version from `0.2.2` to `0.2.3`.
* Modified the URL for the `darwin_amd64` case in the `check_opa_existence` method to remove the `_static` suffix.